### PR TITLE
UPD: added missing fields to JIRA connector: self, key, description

### DIFF
--- a/connectors/jira/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/jira/JiraRepositoryConnector.java
+++ b/connectors/jira/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/jira/JiraRepositoryConnector.java
@@ -996,6 +996,9 @@ public class JiraRepositoryConnector extends BaseRepositoryConnector {
             if (modifiedDate != null)
               rd.setModifiedDate(modifiedDate);
             
+            rd.addField("key", jiraFile.getKey());
+            rd.addField("self", jiraFile.getSelf());
+            rd.addField("description", jiraFile.getDescription());
             // Get general document metadata
             Map<String,String[]> metadataMap = jiraFile.getMetadata();
               


### PR DESCRIPTION
Added the fields key, description and self as they are not in the metadata but can be accessed from jiraFile itself.
