### PR TITLE
Update LivelinkConnector.java

### DIFF
--- a/connectors/livelink/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/livelink/LivelinkConnector.java
+++ b/connectors/livelink/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/livelink/LivelinkConnector.java
@@ -3262,7 +3262,7 @@ public class LivelinkConnector extends org.apache.manifoldcf.crawler.connectors.
       String op = variableContext.getParameter(seqPrefix+"pathop");
       if (op != null && op.equals("Add"))
       {
-        String path = variableContext.getParameter("specpath");
+        String path = variableContext.getParameter(seqPrefix+"specpath");
         SpecificationNode node = new SpecificationNode("startpoint");
         node.setAttribute("path",path);
         ds.addChild(ds.getChildCount(),node);


### PR DESCRIPTION
Hi Karl Wright,

There was a bug in this file since version 1.8, when we try to add a Livelink folder in Path tab, it was breaking and today I found that this was because, you missed seqPrefix+ in line no 3265, Please consider changing this in the next release.
Now since, I became more familiar with ManifoldCF architecture, I may be try to find more bug in livelink connector here on.

Thanks for such a great tool to index.
