### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,7 @@
           <fork>true</fork>
           <meminitial>128m</meminitial>
           <maxmem>512m</maxmem>
+        	<useIncrementalCompilation>true</useIncrementalCompilation>
         </configuration>
       </plugin>
 


### PR DESCRIPTION

Maven can recompile only the classes that were affected by a change. This feature is the default. We can activate it by setting `<useIncrementalCompilation>true</useIncrementalCompilation>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
