### PR TITLE
Add non-emptiness clause to realm check of Solr output connector

### DIFF
--- a/connectors/solr/connector/src/main/java/org/apache/manifoldcf/agents/output/solr/HttpPoster.java
+++ b/connectors/solr/connector/src/main/java/org/apache/manifoldcf/agents/output/solr/HttpPoster.java
@@ -285,7 +285,7 @@ public class HttpPoster
     {
       CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
       Credentials credentials = new UsernamePasswordCredentials(userID, password);
-      if (realm != null)
+      if (realm != null && realm.trim().length() > 0)
         credentialsProvider.setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT, realm), credentials);
       else
         credentialsProvider.setCredentials(AuthScope.ANY, credentials);


### PR DESCRIPTION
The underlying HTTP client of the Solr output connector always configures a dedicated `AuthScope` of the connection, even if the provided `realm` is the empty string (`""`). This is due to the fact that the attribute `realm` is never `null`, but `""` in case the user did not supply a parameter for this. This breaks connectivity in case basic authentication is in-place, but no realm is required. Thus, in both cases (`null` value and `""` for realm) the HTTP client should use `AuthScope.ANY`. This commit adds the necessary non-emptiness clause to the realm check in order to fix this behavior.