### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/connectors/activedirectory/pom.xml
+++ b/connectors/activedirectory/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/alfresco-webscript/pom.xml
+++ b/connectors/alfresco-webscript/pom.xml
@@ -118,7 +118,7 @@
                         <exclude>**/*Postgresql*.java</exclude>
                         <exclude>**/*MySQL*.java</exclude>
                     </excludes>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                     <workingDirectory>target/test-output</workingDirectory>
                 </configuration>

--- a/connectors/alfresco/pom.xml
+++ b/connectors/alfresco/pom.xml
@@ -184,7 +184,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/amazoncloudsearch/pom.xml
+++ b/connectors/amazoncloudsearch/pom.xml
@@ -140,7 +140,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/amazons3/pom.xml
+++ b/connectors/amazons3/pom.xml
@@ -151,7 +151,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/cmis/pom.xml
+++ b/connectors/cmis/pom.xml
@@ -150,7 +150,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/confluence-v6/pom.xml
+++ b/connectors/confluence-v6/pom.xml
@@ -148,7 +148,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/confluence/pom.xml
+++ b/connectors/confluence/pom.xml
@@ -145,7 +145,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/contentlimiter/pom.xml
+++ b/connectors/contentlimiter/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/csws/pom.xml
+++ b/connectors/csws/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/documentfilter/pom.xml
+++ b/connectors/documentfilter/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/dropbox/pom.xml
+++ b/connectors/dropbox/pom.xml
@@ -146,7 +146,7 @@
                   <exclude>**/*Postgresql*.java</exclude>
                   <exclude>**/*MySQL*.java</exclude>
                 </excludes>
-                <forkCount>1</forkCount>
+                <forkCount>1.5C</forkCount>
                 <reuseForks>false</reuseForks>
                 <workingDirectory>target/test-output</workingDirectory>
               </configuration>

--- a/connectors/elasticsearch/pom.xml
+++ b/connectors/elasticsearch/pom.xml
@@ -155,7 +155,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/email/pom.xml
+++ b/connectors/email/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/filesystem/pom.xml
+++ b/connectors/filesystem/pom.xml
@@ -140,7 +140,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/forcedmetadata/pom.xml
+++ b/connectors/forcedmetadata/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/generic/pom.xml
+++ b/connectors/generic/pom.xml
@@ -134,7 +134,7 @@
                   <exclude>**/*Postgresql*.java</exclude>
                   <exclude>**/*MySQL*.java</exclude>
                 </excludes>
-                <forkCount>1</forkCount>
+                <forkCount>1.5C</forkCount>
                 <reuseForks>false</reuseForks>
                 <workingDirectory>target/test-output</workingDirectory>
               </configuration>

--- a/connectors/googledrive/pom.xml
+++ b/connectors/googledrive/pom.xml
@@ -148,7 +148,7 @@
                   <exclude>**/*Postgresql*.java</exclude>
                   <exclude>**/*MySQL*.java</exclude>
                 </excludes>
-                <forkCount>1</forkCount>
+                <forkCount>1.5C</forkCount>
                 <reuseForks>false</reuseForks>
                 <workingDirectory>target/test-output</workingDirectory>
               </configuration>

--- a/connectors/gridfs/pom.xml
+++ b/connectors/gridfs/pom.xml
@@ -54,7 +54,7 @@
                         <exclude>**/*Postgresql*.java</exclude>
                         <exclude>**/*MySQL*.java</exclude>
                     </excludes>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                     <workingDirectory>target/test-output</workingDirectory>
                 </configuration>

--- a/connectors/gts/pom.xml
+++ b/connectors/gts/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/hdfs/pom.xml
+++ b/connectors/hdfs/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/html-extractor/pom.xml
+++ b/connectors/html-extractor/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/jcifs/pom.xml
+++ b/connectors/jcifs/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/jdbc/pom.xml
+++ b/connectors/jdbc/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/jira/pom.xml
+++ b/connectors/jira/pom.xml
@@ -148,7 +148,7 @@
                   <exclude>**/*Postgresql*.java</exclude>
                   <exclude>**/*MySQL*.java</exclude>
                 </excludes>
-                <forkCount>1</forkCount>
+                <forkCount>1.5C</forkCount>
                 <reuseForks>false</reuseForks>
                 <workingDirectory>target/test-output</workingDirectory>
               </configuration>

--- a/connectors/ldap/pom.xml
+++ b/connectors/ldap/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/mongodb/pom.xml
+++ b/connectors/mongodb/pom.xml
@@ -339,7 +339,7 @@
                         <exclude>**/*Postgresql*.java</exclude>
                         <exclude>**/*MySQL*.java</exclude>
                     </excludes>
-                    <forkCount>1</forkCount>
+                    <forkCount>1.5C</forkCount>
                     <reuseForks>false</reuseForks>
                     <workingDirectory>target/test-output</workingDirectory>
                 </configuration>

--- a/connectors/nullauthority/pom.xml
+++ b/connectors/nullauthority/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/nulloutput/pom.xml
+++ b/connectors/nulloutput/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/nulltransformation/pom.xml
+++ b/connectors/nulltransformation/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/nuxeo/pom.xml
+++ b/connectors/nuxeo/pom.xml
@@ -163,7 +163,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/opensearchserver/pom.xml
+++ b/connectors/opensearchserver/pom.xml
@@ -142,7 +142,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/regexpmapper/pom.xml
+++ b/connectors/regexpmapper/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/rocketchat/pom.xml
+++ b/connectors/rocketchat/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/rss/pom.xml
+++ b/connectors/rss/pom.xml
@@ -140,7 +140,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/searchblox/pom.xml
+++ b/connectors/searchblox/pom.xml
@@ -135,7 +135,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/sharepoint/pom.xml
+++ b/connectors/sharepoint/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/slack/pom.xml
+++ b/connectors/slack/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/solr/pom.xml
+++ b/connectors/solr/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/tika/pom.xml
+++ b/connectors/tika/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/tikaservice/pom.xml
+++ b/connectors/tikaservice/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/webcrawler/pom.xml
+++ b/connectors/webcrawler/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/connectors/wiki/pom.xml
+++ b/connectors/wiki/pom.xml
@@ -133,7 +133,7 @@
             <exclude>**/*Postgresql*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/framework/agents/pom.xml
+++ b/framework/agents/pom.xml
@@ -50,7 +50,7 @@
             <exclude>**/*HSQLDBext*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/framework/connector-common/pom.xml
+++ b/framework/connector-common/pom.xml
@@ -47,7 +47,7 @@
           <excludes>
             <exclude>**/*Postgresql*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/framework/core/pom.xml
+++ b/framework/core/pom.xml
@@ -47,7 +47,7 @@
           <excludes>
             <exclude>**/*Postgresql*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>

--- a/framework/pull-agent/pom.xml
+++ b/framework/pull-agent/pom.xml
@@ -49,7 +49,7 @@
             <exclude>**/*HSQLDBext*.java</exclude>
             <exclude>**/*MySQL*.java</exclude>
           </excludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <workingDirectory>target/test-output</workingDirectory>
         </configuration>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
