### PR TITLE
The Solr Output Connector should retry on a 502 Bad Gateway or 503 Service Unavailable

### DIFF
--- a/connectors/solr/connector/src/main/java/org/apache/manifoldcf/agents/output/solr/HttpPoster.java
+++ b/connectors/solr/connector/src/main/java/org/apache/manifoldcf/agents/output/solr/HttpPoster.java
@@ -477,7 +477,7 @@ public class HttpPoster
     
     // The only other kind of return code we know how to handle is 50x.
     // For these, we should retry for a while.
-    if (code == 500)
+    if (code == 500 || code == 502 || code == 503)
     {
       long currentTime = System.currentTimeMillis();
       


### PR DESCRIPTION
Treat Solr response with HTTP status code 502 or 503 as retriable error condition.