### PR TITLE
Wecrawler connector - Add "Force inclusion of redirections" option

### DIFF
--- a/connectors/webcrawler/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/webcrawler/WebcrawlerConfig.java
+++ b/connectors/webcrawler/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/webcrawler/WebcrawlerConfig.java
@@ -147,6 +147,10 @@ public class WebcrawlerConfig
 
   /** Limit to seeds.  When value attribute is true, only seed domains will be permitted. */
   public static final String NODE_LIMITTOSEEDS = "limittoseeds";
+
+  /** Force the inclusion of redirections.  When value attribute is true, redirected URL will be included. */
+  public static final String NODE_FORCEINCLUSION = "forceinclusionofredirects";
+
   /** Canonicalization rule.  Attributes are regexp, description, reorder, 
   *javasessionremoval, aspsessionremoval, phpsessionremoval, bvsessionremoval */
   public static final String NODE_URLSPEC = "urlspec";

--- a/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_en_US.properties
+++ b/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_en_US.properties
@@ -75,6 +75,7 @@ WebcrawlerConnector.AddUrlRegexp=Add url regexp
 WebcrawlerConnector.IncludeInCrawl=Include in crawl:
 WebcrawlerConnector.IncludeInIndex=Include in index:
 WebcrawlerConnector.IncludeOnlyHostsMatchingSeeds=Include only hosts matching seeds?
+WebcrawlerConnector.ForceInclusionOfRedirects=Force the inclusion of redirections (overwrites the Include only hosts option above)
 WebcrawlerConnector.ExcludeFromCrawl=Exclude from crawl:
 WebcrawlerConnector.ExcludeFromIndex=Exclude from index:
 WebcrawlerConnector.ExcludeContentFromIndex=Exclude content from index:

--- a/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_es_ES.properties
+++ b/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_es_ES.properties
@@ -75,6 +75,7 @@ WebcrawlerConnector.AddUrlRegexp=Añadir regexp url
 WebcrawlerConnector.IncludeInCrawl=Incluir en rastreo:
 WebcrawlerConnector.IncludeInIndex=Incluir en el índice:
 WebcrawlerConnector.IncludeOnlyHostsMatchingSeeds=Incluya sólo los hosts que emparejan semillas?
+WebcrawlerConnector.ForceInclusionOfRedirects=Force the inclusion of redirections (overwrites the Include only hosts option above)
 WebcrawlerConnector.ExcludeFromCrawl=Excluir de rastreo:
 WebcrawlerConnector.ExcludeFromIndex=Excluir del índice:
 WebcrawlerConnector.ExcludeContentFromIndex=Excluir contenido del índice:

--- a/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_fr_FR.properties
+++ b/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_fr_FR.properties
@@ -75,6 +75,7 @@ WebcrawlerConnector.AddUrlRegexp=Ajouter expression régulière d'url
 WebcrawlerConnector.IncludeInCrawl=Inclure dans le crawl:
 WebcrawlerConnector.IncludeInIndex=Inclure dans l'index:
 WebcrawlerConnector.IncludeOnlyHostsMatchingSeeds=Inclure uniquement les seeds de matching d'hôtes (hosts matching seeds)?
+WebcrawlerConnector.ForceInclusionOfRedirects=Forcer l'inclusion des redirections (écrase l'option ci-dessus)
 WebcrawlerConnector.ExcludeFromCrawl=Exclure du crawl:
 WebcrawlerConnector.ExcludeFromIndex=Exclure de l'index:
 WebcrawlerConnector.DeleteToken=Supprimer le jeton #

--- a/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_ja_JP.properties
+++ b/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_ja_JP.properties
@@ -75,6 +75,7 @@ WebcrawlerConnector.AddUrlRegexp=URL正規表現に追加
 WebcrawlerConnector.IncludeInCrawl=クロールに含める：
 WebcrawlerConnector.IncludeInIndex=索引に含める：
 WebcrawlerConnector.IncludeOnlyHostsMatchingSeeds=シードと一致するホストのみ対象にする
+WebcrawlerConnector.ForceInclusionOfRedirects=Force the inclusion of redirections (overwrites the Include only hosts option above)
 WebcrawlerConnector.ExcludeFromCrawl=クロールから除外：
 WebcrawlerConnector.ExcludeFromIndex=索引が除外：
 WebcrawlerConnector.DeleteToken=トークンを削除 #

--- a/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_zh_CN.properties
+++ b/connectors/webcrawler/connector/src/main/native2ascii/org/apache/manifoldcf/crawler/connectors/webcrawler/common_zh_CN.properties
@@ -75,6 +75,7 @@ WebcrawlerConnector.AddUrlRegexp=添加URL正则表达式
 WebcrawlerConnector.IncludeInCrawl=包含于爬虫内: 
 WebcrawlerConnector.IncludeInIndex=包含于索引内: 
 WebcrawlerConnector.IncludeOnlyHostsMatchingSeeds=只包含和种子匹配的主机
+WebcrawlerConnector.ForceInclusionOfRedirects=Force the inclusion of redirections (overwrites the Include only hosts option above)
 WebcrawlerConnector.ExcludeFromCrawl=排除于爬虫外: 
 WebcrawlerConnector.ExcludeFromIndex=排除于索引外: 
 WebcrawlerConnector.DeleteToken=删除令牌 #

--- a/connectors/webcrawler/connector/src/main/resources/org/apache/manifoldcf/crawler/connectors/webcrawler/editSpecification_Inclusions.html.vm
+++ b/connectors/webcrawler/connector/src/main/resources/org/apache/manifoldcf/crawler/connectors/webcrawler/editSpecification_Inclusions.html.vm
@@ -33,11 +33,18 @@
         <input type="hidden" name="${SEQPREFIX}matchinghosts_present" value="true"/>
       </div>
     </div>
+    <div class="form-group">
+      <div class="checkbox">
+        <label><input type="checkbox" name="${SEQPREFIX}forceInclusion" value="true" #if($FORCEINCLUSION) checked="yes" #end />$Encoder.bodyEscape($ResourceBundle.getString('WebcrawlerConnector.ForceInclusionOfRedirects'))</label>
+        <input type="hidden" name="${SEQPREFIX}forceinclusion_present" value="true"/>
+      </div>
+    </div>
   </div>
 </div>
 #else
 <input type="hidden" name="${SEQPREFIX}inclusions" value="$Encoder.attributeEscape($INCLUSIONS)"/>
 <input type="hidden" name="${SEQPREFIX}inclusionsindex" value="$Encoder.attributeEscape($INCLUSIONSINDEX)"/>
 <input type="hidden" name="${SEQPREFIX}matchinghosts" value="#if($INCLUDEMATCHING)true#{else}false#end" />
+<input type="hidden" name="${SEQPREFIX}forceInclusion" value="#if($FORCEINCLUSION)true#{else}false#end" />
 <input type="hidden" name="${SEQPREFIX}matchinghosts_present" value="true"/>
 #end

--- a/connectors/webcrawler/connector/src/main/resources/org/apache/manifoldcf/crawler/connectors/webcrawler/viewSpecification.html.vm
+++ b/connectors/webcrawler/connector/src/main/resources/org/apache/manifoldcf/crawler/connectors/webcrawler/viewSpecification.html.vm
@@ -78,6 +78,10 @@
     <td>#if($INCLUDEMATCHING)$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.yes"))#{else}$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.no"))#{end}</td>
   </tr>
   <tr>
+    <th>$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.ForceInclusionOfRedirects"))</th>
+    <td>#if($FORCEINCLUSION)$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.yes"))#{else}$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.no"))#{end}</td>
+  </tr>
+  <tr>
     <th>$Encoder.bodyEscape($ResourceBundle.getString("WebcrawlerConnector.IncludeInCrawl"))</th>
     <td><pre>$Encoder.bodyEscape($INCLUSIONS)</pre></td>
   </tr>


### PR DESCRIPTION
The "Force the inclusion of redirection” options allows you to include hosts redirected from original seeds. You might want to use this option if the site you are crawling is subject to redirections. Note that it is not required if the previous option is not checked. Here are the possible behaviors:

- If the user checks the “Include only hosts”, but not the “Force the inclusion” option, then the redirected files will be filtered if their new URL doesn’t match the seed.
- If the user checks the Include only hosts, and checks the Force the inclusion option, then when the job finds a url that is not in the same domain, it is dropped EXCEPT if the url is originated by a 301 or 302 redirection in the document queue.
- If the user does NOT check the include only hosts, but checks the Force the inclusion option, then the job will crawl any url found, even if it is originated by a 301 or 302 redirection.
- If the user does not check anything, then the behavior is the same as the previous case.

If the admin checks the second option AND if the first option is checked, then the job will check any host added in the Set. If a host is subject to redirection, then we add the destination URL in the Set.