### PR TITLE
Fix test org.apache.manifoldcf.agents.output.kafka.APISanityHSQLDBIT failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,8 @@
 /dist/
 lib-proprietary/*.jar
 site/fonts/
+/.DS_Store
+*.class
+/connectors/*/target/classes
+/connectors/*/target/generated-sources
+/connectors/*/target/test-classes

--- a/build.xml
+++ b/build.xml
@@ -36,8 +36,8 @@
     <property name="httpmime.version" value="4.5.13"/>
     <property name="httpcore.version" value="4.4.15"/>
     <property name="xerces.version" value="2.12.2"/>
-    <property name="zookeeper.version" value="3.8.0"/>
-    <property name="metrics-core.version" value="4.1.12.1"/>
+    <property name="zookeeper.version" value="3.9.1"/>
+    <property name="metrics-core.version" value="4.2.21"/>
     <property name="snappy-java.version" value="1.1.7.7"/>
     <property name="mongodb.version" value="2.14.3"/>
     <property name="postgresql.version" value="42.1.3"/>
@@ -2198,7 +2198,7 @@ Use Apache Forrest version forrest-0.9-dev or higher.
         <antcall target="download-via-maven">
             <param name="target" value="lib"/>
             <param name="project-path" value="org/apache/kafka"/>
-            <param name="artifact-version" value="0.8.2.1"/>
+            <param name="artifact-version" value="3.6.0"/>
             <param name="artifact-name" value="kafka-clients"/>
             <param name="artifact-type" value="jar"/>
         </antcall>

--- a/connectors/kafka/build.xml
+++ b/connectors/kafka/build.xml
@@ -30,7 +30,7 @@
 
     <import file="${mcf-dist}/connector-build.xml"/>
 
-    <property name="kafka.version" value="0.8.2.1"/>
+    <property name="kafka.version" value="3.6.0"/>
 
     <path id="connector-classpath">
         <path refid="mcf-connector-build.connector-classpath"/>
@@ -58,7 +58,56 @@
             <param name="target" value="test-materials"/>
             <param name="project-path" value="org/apache/kafka"/>
             <param name="artifact-version" value="${kafka.version}"/>
-            <param name="artifact-name" value="kafka_2.11"/>
+            <param name="artifact-name" value="kafka_2.13"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/apache/kafka"/>
+            <param name="artifact-version" value="${kafka.version}"/>
+            <param name="artifact-name" value="kafka-server-common"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/apache/kafka"/>
+            <param name="artifact-version" value="${kafka.version}"/>
+            <param name="artifact-name" value="kafka-group-coordinator"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/apache/kafka"/>
+            <param name="artifact-version" value="${kafka.version}"/>
+            <param name="artifact-name" value="kafka-raft"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/apache/kafka"/>
+            <param name="artifact-version" value="${kafka.version}"/>
+            <param name="artifact-name" value="kafka-storage"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/apache/kafka"/>
+            <param name="artifact-version" value="${kafka.version}"/>
+            <param name="artifact-name" value="kafka-metadata"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="com/typesafe/scala-logging"/>
+            <param name="artifact-version" value="3.9.5"/>
+            <param name="artifact-name" value="scala-logging_3"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="commons-validator"/>
+            <param name="artifact-version" value="1.7"/>
+            <param name="artifact-name" value="commons-validator"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven">
@@ -78,29 +127,29 @@
         <antcall target="download-via-maven">
             <param name="target" value="test-materials"/>
             <param name="project-path" value="org/scala-lang"/>
-            <param name="artifact-version" value="2.11.0"/>
+            <param name="artifact-version" value="2.13.11"/>
             <param name="artifact-name" value="scala-library"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven">
             <param name="target" value="test-materials"/>
             <param name="project-path" value="net/sf/jopt-simple"/>
-            <param name="artifact-version" value="3.2"/>
+            <param name="artifact-version" value="5.0.4"/>
             <param name="artifact-name" value="jopt-simple"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven">
             <param name="target" value="test-materials"/>
             <param name="project-path" value="org/scala-lang/modules"/>
-            <param name="artifact-version" value="1.0.4"/>
-            <param name="artifact-name" value="scala-xml_2.11"/>
+            <param name="artifact-version" value="2.2.0"/>
+            <param name="artifact-name" value="scala-xml_2.13"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven">
             <param name="target" value="test-materials"/>
             <param name="project-path" value="org/scala-lang/modules"/>
-            <param name="artifact-version" value="1.0.4"/>
-            <param name="artifact-name" value="scala-parser-combinators_2.11"/>
+            <param name="artifact-version" value="2.2.0"/>
+            <param name="artifact-name" value="scala-parser-combinators_2.13"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven">
@@ -108,6 +157,20 @@
             <param name="project-path" value="com/101tec"/>
             <param name="artifact-version" value="0.6"/>
             <param name="artifact-name" value="zkclient"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="io/netty"/>
+            <param name="artifact-version" value="4.1.100.Final"/>
+            <param name="artifact-name" value="netty-handler"/>
+            <param name="artifact-type" value="jar"/>
+        </antcall>
+        <antcall target="download-via-maven">
+            <param name="target" value="test-materials"/>
+            <param name="project-path" value="org/scala-lang/modules"/>
+            <param name="artifact-version" value="1.0.2"/>
+            <param name="artifact-name" value="scala-java8-compat_3"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
     </target>
@@ -119,7 +182,7 @@
     </target>
 
     <target name="calculate-testcode-condition">
-        <available file="test-materials/kafka_2.11-${kafka.version}.jar" property="tests-present"/>
+        <available file="test-materials/kafka_2.13-${kafka.version}.jar" property="tests-present"/>
     </target>
 
     <target name="pretest-warn" depends="calculate-testcode-condition" unless="tests-present">
@@ -133,6 +196,7 @@
             <include name="kafka-clients*.jar"/>
             <include name="lz4*.jar"/>
             <include name="snappy-java*.jar"/>
+            <include name="metrics-core*.jar"/>
         </fileset>
         <fileset dir="test-materials">
             <include name="zkclient*.jar"/>
@@ -140,9 +204,17 @@
             <include name="metrics-core*.jar"/>
             <include name="jopt-simple*.jar"/>
             <include name="scala-library*.jar"/>
-            <include name="kafka_2.11*.jar"/>
-            <include name="scala-xml_2.11*.jar"/>
-            <include name="scala-parser-combinators_2.11*.jar"/>
+            <include name="kafka_2.13*.jar"/>
+            <include name="kafka-server-common*.jar"/>
+            <include name="kafka-group-coordinator*.jar"/>
+            <include name="kafka-raft*.jar"/>
+            <include name="kafka-storage*.jar"/>
+            <include name="kafka-metadata*.jar"/>
+            <include name="scala-logging_3*.jar"/>
+            <include name="commons-validator*.jar"/>
+            <include name="scala-parser-combinators_2.13*.jar"/>
+            <include name="netty-handler*.jar"/>
+            <include name="scala-java8-compat_3*.jar"/>
         </fileset>
     </path>
 

--- a/connectors/kafka/connector/src/main/java/org/apache/manifoldcf/agents/output/kafka/KafkaOutputConnector.java
+++ b/connectors/kafka/connector/src/main/java/org/apache/manifoldcf/agents/output/kafka/KafkaOutputConnector.java
@@ -133,7 +133,6 @@ public class KafkaOutputConnector extends org.apache.manifoldcf.agents.output.Ba
     props.put(ProducerConfig.ACKS_CONFIG, "all");
     props.put(ProducerConfig.COMPRESSION_TYPE_CONFIG, "none");
     props.put(ProducerConfig.BATCH_SIZE_CONFIG, 200);
-    props.put(ProducerConfig.BLOCK_ON_BUFFER_FULL_CONFIG, true);
     props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.StringSerializer");
     props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "org.apache.kafka.common.serialization.ByteArraySerializer");
     producer = new KafkaProducer(props);

--- a/connectors/kafka/connector/src/test/java/org/apache/manifoldcf/agents/output/kafka/KafkaLocal.java
+++ b/connectors/kafka/connector/src/test/java/org/apache/manifoldcf/agents/output/kafka/KafkaLocal.java
@@ -18,12 +18,13 @@ package org.apache.manifoldcf.agents.output.kafka;
 
 import java.io.IOException;
 import java.util.Properties;
+import org.apache.kafka.common.utils.Time;
 import kafka.server.KafkaConfig;
-import kafka.server.KafkaServerStartable;
+import kafka.server.KafkaServer;
 
 public class KafkaLocal {
 
-  public KafkaServerStartable kafka;
+  public KafkaServer kafka;
   public ZooKeeperLocal zookeeper;
 
   public KafkaLocal(Properties kafkaProperties, Properties zkProperties) throws IOException, InterruptedException {
@@ -35,7 +36,7 @@ public class KafkaLocal {
     System.out.println("done");
 
     //start local kafka broker
-    kafka = new KafkaServerStartable(kafkaConfig);
+    kafka = new KafkaServer(kafkaConfig, Time.SYSTEM, scala.Option.empty(), false);
     System.out.println("starting local kafka broker...");
 
     kafka.startup();

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -224,12 +224,12 @@
     <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
-      <version>0.8.2.1</version>
+      <version>3.6.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka_2.11</artifactId>
-      <version>0.8.2.1</version>
+      <artifactId>kafka_2.13</artifactId>
+      <version>3.6.0</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>
@@ -239,27 +239,69 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-server-common</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-group-coordinator</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-raft</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-storage</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-metadata</artifactId>
+      <version>3.6.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_3</artifactId>
+      <version>3.9.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-validator</groupId>
+      <artifactId>commons-validator</artifactId>
+      <version>1.7</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.0</version>
+      <version>2.13.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>net.sf.jopt-simple</groupId>
       <artifactId>jopt-simple</artifactId>
-      <version>3.2</version>
+      <version>5.0.4</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-xml_2.11</artifactId>
-      <version>1.0.4</version>
+      <artifactId>scala-xml_2.13</artifactId>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-parser-combinators_2.11</artifactId>
-      <version>1.0.4</version>
+      <artifactId>scala-parser-combinators_2.13</artifactId>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -267,6 +309,17 @@
       <artifactId>metrics-core</artifactId>
       <version>2.2.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <version>4.2.21</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-java8-compat_3</artifactId>
+      <version>1.0.2</version>
     </dependency>
     
     <dependency>
@@ -461,6 +514,12 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-handler</artifactId>
+      <version>4.1.100.Final</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/framework/core/pom.xml
+++ b/framework/core/pom.xml
@@ -235,7 +235,7 @@
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-core</artifactId>
-      <version>4.1.12.1</version>
+      <version>4.2.21</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <velocity-engine-core.version>2.3</velocity-engine-core.version>
     <slf4j.version>1.7.36</slf4j.version>
     <jaxb.version>2.2.6</jaxb.version>
-    <zookeeper.version>3.8.0</zookeeper.version>
+    <zookeeper.version>3.9.1</zookeeper.version>
     <xmlbeans.version>2.6.0</xmlbeans.version>
     <poi.version>3.17</poi.version>
     <tika.version>1.28.1</tika.version>


### PR DESCRIPTION
Updated Kafka and its dependencies to the latest version including zookeeper.
Confirmed kafka test passed as below.

```
~manifoldcf% cd connectors/kafka
~manifoldcf/connectors/kafka/% ant run-IT-HSQLDB

BUILD SUCCESSFUL
Total time: 1 minute 19 seconds
```
