### PR TITLE
fix zookeeper linkage error

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -36,7 +36,7 @@
     <property name="httpmime.version" value="4.5.13"/>
     <property name="httpcore.version" value="4.4.15"/>
     <property name="xerces.version" value="2.12.2"/>
-    <property name="zookeeper.version" value="3.9.1"/>
+    <property name="zookeeper.version" value="3.8.0"/>
     <property name="metrics-core.version" value="4.2.21"/>
     <property name="snappy-java.version" value="1.1.7.7"/>
     <property name="mongodb.version" value="2.14.3"/>

--- a/connectors/kafka/build.xml
+++ b/connectors/kafka/build.xml
@@ -159,20 +159,6 @@
             <param name="artifact-name" value="zkclient"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
-        <antcall target="download-via-maven">
-            <param name="target" value="test-materials"/>
-            <param name="project-path" value="io/netty"/>
-            <param name="artifact-version" value="4.1.100.Final"/>
-            <param name="artifact-name" value="netty-handler"/>
-            <param name="artifact-type" value="jar"/>
-        </antcall>
-        <antcall target="download-via-maven">
-            <param name="target" value="test-materials"/>
-            <param name="project-path" value="org/scala-lang/modules"/>
-            <param name="artifact-version" value="1.0.2"/>
-            <param name="artifact-name" value="scala-java8-compat_3"/>
-            <param name="artifact-type" value="jar"/>
-        </antcall>
     </target>
 
     <target name="download-cleanup">
@@ -213,8 +199,6 @@
             <include name="scala-logging_3*.jar"/>
             <include name="commons-validator*.jar"/>
             <include name="scala-parser-combinators_2.13*.jar"/>
-            <include name="netty-handler*.jar"/>
-            <include name="scala-java8-compat_3*.jar"/>
         </fileset>
     </path>
 

--- a/connectors/kafka/pom.xml
+++ b/connectors/kafka/pom.xml
@@ -316,11 +316,6 @@
       <version>4.2.21</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.scala-lang.modules</groupId>
-      <artifactId>scala-java8-compat_3</artifactId>
-      <version>1.0.2</version>
-    </dependency>
     
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -514,12 +509,6 @@
           <artifactId>log4j</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-handler</artifactId>
-      <version>4.1.100.Final</version>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <velocity-engine-core.version>2.3</velocity-engine-core.version>
     <slf4j.version>1.7.36</slf4j.version>
     <jaxb.version>2.2.6</jaxb.version>
-    <zookeeper.version>3.9.1</zookeeper.version>
+    <zookeeper.version>3.8.0</zookeeper.version>
     <xmlbeans.version>2.6.0</xmlbeans.version>
     <poi.version>3.17</poi.version>
     <tika.version>1.28.1</tika.version>    <boilerpipe.version>1.1.0</boilerpipe.version>


### PR DESCRIPTION
Reverted zookeeper version to 3.8.0 to avoid multiThreadZooKeeperLockTest error:

[junit] Caused by: java.lang.ClassNotFoundException: io.netty.handler.ssl.SslContext