### PR TITLE
A new generic authority connector for JSON data exchange format

### DIFF
--- a/connectors/csv/pom.xml
+++ b/connectors/csv/pom.xml
@@ -15,6 +15,7 @@
  limitations under the License.
 -->
 
+<?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/connectors/newgeneric/build.xml
+++ b/connectors/newgeneric/build.xml
@@ -1,0 +1,40 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements. See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<project name="newgeneric" default="all">
+
+    <property environment="env"/>
+    <condition property="mcf-dist" value="${env.MCFDISTPATH}">
+        <isset property="env.MCFDISTPATH"/>
+    </condition>
+    <property name="abs-dist" location="../../dist"/>
+    <condition property="mcf-dist" value="${abs-dist}">
+        <not>
+            <isset property="env.MCFDISTPATH"/>
+        </not>
+    </condition>
+
+    <import file="${mcf-dist}/connector-build.xml"/>
+
+    <target name="deliver-connector" depends="mcf-connector-build.deliver-connector">
+        <antcall target="general-add-authority-connector">
+            <param name="connector-label" value="New Generic"/>
+            <param name="connector-class" value="org.apache.manifoldcf.authorities.authorities.newgeneric.NewGenericAuthority"/>
+        </antcall>
+    </target>
+
+</project>

--- a/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/Messages.java
+++ b/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/Messages.java
@@ -1,0 +1,121 @@
+/* $Id: Messages.java 1295926 2012-03-01 21:56:27Z kwright $ */
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with this
+ * work for additional information regarding copyright ownership. The ASF
+ * licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+* http://www.apache.org/licenses/LICENSE-2.0
+ * 
+* Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.manifoldcf.authorities.authorities.newgeneric;
+
+import java.util.Locale;
+import java.util.Map;
+import org.apache.manifoldcf.core.interfaces.IHTTPOutput;
+import org.apache.manifoldcf.core.interfaces.ManifoldCFException;
+
+public class Messages extends org.apache.manifoldcf.ui.i18n.Messages {
+
+  public static final String DEFAULT_BUNDLE_NAME = "org.apache.manifoldcf.authorities.authorities.newgeneric.common";
+
+  public static final String DEFAULT_PATH_NAME = "org.apache.manifoldcf.authorities.authorities.newgeneric";
+
+
+
+  /**
+   * Constructor - do no instantiate
+   */
+  protected Messages() {
+  }
+
+  public static String getString(Locale locale, String messageKey) {
+    return getString(DEFAULT_BUNDLE_NAME, locale, messageKey, null);
+  }
+
+  public static String getAttributeString(Locale locale, String messageKey) {
+    return getAttributeString(DEFAULT_BUNDLE_NAME, locale, messageKey, null);
+  }
+
+  public static String getBodyString(Locale locale, String messageKey) {
+    return getBodyString(DEFAULT_BUNDLE_NAME, locale, messageKey, null);
+  }
+
+  public static String getAttributeJavascriptString(Locale locale, String messageKey) {
+    return getAttributeJavascriptString(DEFAULT_BUNDLE_NAME, locale, messageKey, null);
+  }
+
+  public static String getBodyJavascriptString(Locale locale, String messageKey) {
+    return getBodyJavascriptString(DEFAULT_BUNDLE_NAME, locale, messageKey, null);
+  }
+
+  public static String getString(Locale locale, String messageKey, Object[] args) {
+    return getString(DEFAULT_BUNDLE_NAME, locale, messageKey, args);
+  }
+
+  public static String getAttributeString(Locale locale, String messageKey, Object[] args) {
+    return getAttributeString(DEFAULT_BUNDLE_NAME, locale, messageKey, args);
+  }
+
+  public static String getBodyString(Locale locale, String messageKey, Object[] args) {
+    return getBodyString(DEFAULT_BUNDLE_NAME, locale, messageKey, args);
+  }
+
+  public static String getAttributeJavascriptString(Locale locale, String messageKey, Object[] args) {
+    return getAttributeJavascriptString(DEFAULT_BUNDLE_NAME, locale, messageKey, args);
+  }
+
+  public static String getBodyJavascriptString(Locale locale, String messageKey, Object[] args) {
+    return getBodyJavascriptString(DEFAULT_BUNDLE_NAME, locale, messageKey, args);
+  }
+
+  // More general methods which allow bundlenames and class loaders to be specified.
+  public static String getString(String bundleName, Locale locale, String messageKey, Object[] args) {
+    return getString(Messages.class, bundleName, locale, messageKey, args);
+  }
+
+  public static String getAttributeString(String bundleName, Locale locale, String messageKey, Object[] args) {
+    return getAttributeString(Messages.class, bundleName, locale, messageKey, args);
+  }
+
+  public static String getBodyString(String bundleName, Locale locale, String messageKey, Object[] args) {
+    return getBodyString(Messages.class, bundleName, locale, messageKey, args);
+  }
+
+  public static String getAttributeJavascriptString(String bundleName, Locale locale, String messageKey, Object[] args) {
+    return getAttributeJavascriptString(Messages.class, bundleName, locale, messageKey, args);
+  }
+
+  public static String getBodyJavascriptString(String bundleName, Locale locale, String messageKey, Object[] args) {
+    return getBodyJavascriptString(Messages.class, bundleName, locale, messageKey, args);
+  }
+
+  // Resource output
+  public static void outputResource(IHTTPOutput output, Locale locale, String resourceKey,
+    Map<String, String> substitutionParameters, boolean mapToUpperCase)
+    throws ManifoldCFException {
+    outputResource(output, Messages.class, DEFAULT_PATH_NAME, locale, resourceKey,
+      substitutionParameters, mapToUpperCase);
+  }
+
+  public static void outputResourceWithVelocity(IHTTPOutput output, Locale locale, String resourceKey,
+    Map<String, String> substitutionParameters, boolean mapToUpperCase)
+    throws ManifoldCFException {
+    outputResourceWithVelocity(output, Messages.class, DEFAULT_BUNDLE_NAME, DEFAULT_PATH_NAME, locale, resourceKey,
+      substitutionParameters, mapToUpperCase);
+  }
+
+  public static void outputResourceWithVelocity(IHTTPOutput output, Locale locale, String resourceKey,
+    Map<String, Object> contextObjects)
+    throws ManifoldCFException {
+    outputResourceWithVelocity(output, Messages.class, DEFAULT_BUNDLE_NAME, DEFAULT_PATH_NAME, locale, resourceKey,
+      contextObjects);
+  }
+}

--- a/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/NewGenericAuthority.java
+++ b/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/NewGenericAuthority.java
@@ -1,0 +1,746 @@
+/*
+ * Copyright 2013 The Apache Software Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.manifoldcf.authorities.authorities.newgeneric;
+
+
+import org.apache.http.*;
+import org.apache.http.auth.Credentials;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.config.SocketConfig;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.conn.socket.PlainConnectionSocketFactory;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.DefaultRedirectStrategy;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpRequestExecutor;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.http.ssl.TrustStrategy;
+import org.apache.http.util.EntityUtils;
+import org.apache.manifoldcf.authorities.interfaces.AuthorizationResponse;
+import org.apache.manifoldcf.authorities.system.Logging;
+import org.apache.manifoldcf.core.interfaces.*;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import javax.net.ssl.SSLContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
+
+
+
+
+public class NewGenericAuthority extends org.apache.manifoldcf.authorities.authorities.BaseAuthorityConnector {
+
+
+
+  /**
+   * This is the active directory global deny token. This should be ingested
+   * with all documents.
+   */
+  private static final String globalDenyToken = "DEAD_AUTHORITY";
+
+  private static final AuthorizationResponse unreachableResponse = new AuthorizationResponse(new String[]{globalDenyToken},
+      AuthorizationResponse.RESPONSE_UNREACHABLE);
+
+
+  /** Connection manager */
+  private HttpClientConnectionManager connectionManager = null;
+
+  /** HttpClientBuilder */
+  private HttpClientBuilder builder = null;
+
+  /** Httpclient instance */
+  private CloseableHttpClient httpClient = null;
+
+  /** Connection timeout */
+  private int connectionTimeout = -1;
+
+  /** Socket timeout */
+  private int socketTimeout = -1;
+
+  /** Session timeout */
+  private long sessionTimeout = -1L;
+
+
+  protected final static long sessionExpirationInterval = 300000L;
+
+  private String newgenericLogin = null;
+
+  private String newgenericPassword = null;
+
+  private String newgenericEntryPoint = null;
+
+
+  /** Connection timeout */
+  private String connectionTimeoutString = null;
+
+  /** Socket timeout */
+  private String socketTimeoutString = null;
+
+  private String responseLifeTimeString = null;
+
+  private final int LRUsize = 1000;
+
+  private final long responseLifetime = 60000L;
+
+
+  private static final String EDIT_CONFIGURATION_AUTHORITY_JS = "editConfiguration.js";
+  private static final String EDIT_CONFIGURATION_AUTHORITY_HTML = "editConfiguration_Server.html";
+  private static final String VIEW_CONFIGURATION_AUTHORITY_HTML = "viewConfiguration.html";
+
+
+  /**
+   * Cache manager.
+   */
+  private ICacheManager cacheManager = null;
+
+  /**
+   * Constructor.
+   */
+  public NewGenericAuthority() {
+  }
+
+  protected void getSession() throws ManifoldCFException {
+    if (sessionTimeout == -1L) {
+
+      try {
+        this.connectionTimeout = Integer.parseInt(connectionTimeoutString);
+      } catch (final NumberFormatException e) {
+        throw new ManifoldCFException("Bad connection timeout number: " + connectionTimeoutString);
+      }
+      try {
+        this.socketTimeout = Integer.parseInt(socketTimeoutString);
+      } catch (final NumberFormatException e) {
+        throw new ManifoldCFException("Bad socket timeout number: " + socketTimeoutString);
+      }
+
+      final TrustStrategy acceptingTrustStrategy = (cert, authType) -> true;
+      SSLConnectionSocketFactory sslsf = SSLConnectionSocketFactory.getSocketFactory();
+      try {
+        final SSLContext sslContext = SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
+        sslsf = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+      } catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
+        throw new ManifoldCFException("SSL context initialization failure", e);
+      }
+
+      final PoolingHttpClientConnectionManager poolingConnectionManager = new PoolingHttpClientConnectionManager(
+          RegistryBuilder.<ConnectionSocketFactory> create().register("http", PlainConnectionSocketFactory.getSocketFactory()).register("https", sslsf).build());
+      poolingConnectionManager.setDefaultMaxPerRoute(1);
+      poolingConnectionManager.setValidateAfterInactivity(2000);
+      poolingConnectionManager.setDefaultSocketConfig(SocketConfig.custom().setTcpNoDelay(true).setSoTimeout(socketTimeout).build());
+
+      this.connectionManager = poolingConnectionManager;
+
+      final RequestConfig.Builder requestBuilder = RequestConfig.custom().setCircularRedirectsAllowed(true).setSocketTimeout(socketTimeout).setExpectContinueEnabled(false).setConnectTimeout(connectionTimeout)
+          .setConnectionRequestTimeout(socketTimeout);
+
+      String auth = newgenericLogin + ":" + newgenericPassword;
+      String encodedAuth = Base64.getEncoder().encodeToString(
+        auth.getBytes(StandardCharsets.ISO_8859_1));
+      String authHeader = "Basic " + new String(encodedAuth);
+      final Header basicAuthheader = new BasicHeader(HttpHeaders.AUTHORIZATION, authHeader);
+      final List<Header> headers = new ArrayList<>();
+      headers.add(basicAuthheader);
+      
+      this.builder = HttpClients.custom().setDefaultHeaders(headers).setConnectionManager(connectionManager).disableAutomaticRetries().setDefaultRequestConfig(requestBuilder.build());
+      builder.setRequestExecutor(new HttpRequestExecutor(socketTimeout)).setRedirectStrategy(new DefaultRedirectStrategy());
+      this.httpClient = builder.build();
+    }
+    sessionTimeout = System.currentTimeMillis() + sessionExpirationInterval;
+
+  }
+
+  /**
+   * Set thread context.
+   */
+  @Override
+  public void setThreadContext(IThreadContext tc)
+      throws ManifoldCFException {
+    super.setThreadContext(tc);
+    cacheManager = CacheManagerFactory.make(tc);
+  }
+
+  /**
+   * Connect. The configuration parameters are included.
+   *
+   * @param configParams are the configuration parameters for this connection.
+   */
+  @Override
+  public void connect(ConfigParams configParams) {
+    super.connect(configParams);
+    newgenericEntryPoint = configParams.getParameter(NewGenericConfig.PARAM_ADDRESS);
+    connectionTimeoutString = configParams.getParameter(NewGenericConfig.PARAM_CONNECTIONTIMEOUT);
+    socketTimeoutString = configParams.getParameter(NewGenericConfig.PARAM_SOCKETTIMEOUT);
+    newgenericLogin = configParams.getParameter(NewGenericConfig.PARAM_LOGIN);
+    newgenericPassword = configParams.getParameter(NewGenericConfig.PARAM_PASSWORD);
+    responseLifeTimeString = configParams.getParameter(NewGenericConfig.PARAM_RESPONSELIFETIME); 
+
+    if (newgenericLogin == null) {
+      newgenericLogin = "";
+    }
+
+    if (newgenericPassword == null) {
+      newgenericPassword = "";
+    }
+
+    if (connectionTimeoutString == null) {
+      connectionTimeoutString = NewGenericConfig.CONNECTIONTIMEOUT_DEFAULT;
+    }
+
+    if (socketTimeoutString == null) {
+      socketTimeoutString = NewGenericConfig.SOCKETTIMEOUT_DEFAULT;
+    }
+
+    if (responseLifeTimeString == null) {
+      responseLifeTimeString = NewGenericConfig.RESPONSELIFETIME_DEFAULT;
+    }
+
+
+  }
+
+  /** Expire the current session */
+  protected void expireSession() {
+    httpClient = null;
+    if (connectionManager != null) {
+      connectionManager.shutdown();
+    }
+    connectionManager = null;
+    sessionTimeout = -1L;
+  }
+
+
+
+  /**
+   * Poll. The connection should be closed if it has been idle for too long.
+   */
+  @Override
+  public void poll() {
+    if (System.currentTimeMillis() >= sessionTimeout) {
+      expireSession();
+    }
+    if (connectionManager != null) {
+      connectionManager.closeIdleConnections(60000L, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  /** This method is called to assess whether to count this connector instance should
+   * actually be counted as being connected.
+   *@return true if the connector instance is actually connected.
+   */
+  @Override
+  public boolean isConnected() {
+    return sessionTimeout != -1L;
+  }
+
+
+
+  /**
+   * Check connection for sanity.
+   */
+  @Override
+  public String check() throws ManifoldCFException {
+    getSession();
+    CloseableHttpResponse response = null;
+    try {
+      try {
+        //final String username = "admin@totem.com";
+        Logging.authorityConnectors.debug("Testing API request: " + newgenericEntryPoint);
+        final HttpGet httpGet = new HttpGet(newgenericEntryPoint);
+        response = this.httpClient.execute(httpGet);
+      } catch (final IOException e) {
+        Logging.authorityConnectors.debug("Request failure: " + e.getMessage());
+        return "Connection error: " + e.getMessage();
+      }
+      final int responseCode = response.getStatusLine().getStatusCode();
+      if (responseCode != 200) {
+        Logging.authorityConnectors.debug("Request KO: " + responseCode + " " + response.getStatusLine().getReasonPhrase());
+        return "Bad response: " + response.getStatusLine();
+      } else {
+        Logging.authorityConnectors.debug("Request OK");
+      }
+      return super.check();
+    } finally {
+      if (response != null) {
+        try {
+          response.close();
+        } catch (final IOException e) {
+          return "Connection error: " + e.getMessage();
+        }
+      }
+    }
+  }
+
+  /**
+   * Close the connection. Call this before discarding the repository connector.
+   */
+  @Override
+  public void disconnect()
+      throws ManifoldCFException {
+
+    // Zero out all the stuff that we want to be sure we don't use again
+    newgenericEntryPoint = null;
+    newgenericLogin = null;
+    newgenericPassword = null;
+
+    super.disconnect();
+  }
+
+  protected String createCacheConnectionString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append(newgenericEntryPoint).append("#").append(newgenericLogin);
+    return sb.toString();
+  }
+
+  /**
+   * Obtain the access tokens for a given user name.
+   *
+   * @param userName is the user name or identifier.
+   * @return the response tokens (according to the current authority). (Should
+   * throws an exception only when a condition cannot be properly described
+   * within the authorization response object.)
+   */
+  @Override
+  public AuthorizationResponse getAuthorizationResponse(String userName)
+      throws ManifoldCFException {
+
+    getSession();
+    // Construct a cache description object
+    ICacheDescription objectDescription = new GenericAuthorizationResponseDescription(userName,
+        createCacheConnectionString(), this.responseLifetime, this.LRUsize);
+
+    // Enter the cache
+    ICacheHandle ch = cacheManager.enterCache(new ICacheDescription[]{objectDescription}, null, null);
+    try {
+      ICacheCreateHandle createHandle = cacheManager.enterCreateSection(ch);
+      try {
+        // Lookup the object
+        AuthorizationResponse response = (AuthorizationResponse) cacheManager.lookupObject(createHandle, objectDescription);
+        if (response != null) {
+          if (Logging.authorityConnectors != null) {
+            Logging.authorityConnectors.debug("New generic: response in the cache status: "+response.getResponseStatus());
+          }
+          return response;
+        }
+        // Create the object.
+        response = getAuthorizationResponseUncached(userName);
+        // Save it in the cache
+        cacheManager.saveObject(createHandle, objectDescription, response);
+        // And return it...
+        return response;
+      } finally {
+        cacheManager.leaveCreateSection(createHandle);
+      }
+    } finally {
+      cacheManager.leaveCache(ch);
+    }
+  }
+
+  protected AuthorizationResponse getAuthorizationResponseUncached(String userName)
+      throws ManifoldCFException {
+    StringBuilder url = new StringBuilder(newgenericEntryPoint);
+
+    url.append("?username=").append(userName);
+
+    if (Logging.authorityConnectors != null) {
+      Logging.authorityConnectors.debug("New generic: url: "+url);
+    }
+
+    List<String> permissions = new ArrayList<String>();
+    permissions = getNewGenericUserSecurity(userName);
+
+    if (permissions == null || permissions.isEmpty()) {
+      Logging.authorityConnectors.debug("No security found for user '" + userName + "'");
+      return RESPONSE_USERNOTFOUND_ADDITIVE;
+    }
+
+    Logging.authorityConnectors.debug("Found security groups for user '" + userName + "'");
+    String[] tokens = new String[permissions.size()];
+    int k = 0;
+    while (k < tokens.length) {
+      tokens[k] = (String) permissions.get(k);
+      Logging.authorityConnectors.debug("security group "+k+" for user '" + userName + " " + (String) permissions.get(k) + "'");
+      k++;
+    }
+
+    return new AuthorizationResponse(tokens, AuthorizationResponse.RESPONSE_OK);
+
+
+  }
+
+  /** Get security groups for new generic user */
+  protected List<String> getNewGenericUserSecurity(final String username) throws ManifoldCFException {
+    getSession();
+
+    Logging.authorityConnectors.debug("test username " + username);
+
+    List<String> permissions = new ArrayList<String>();
+    try {
+      Logging.authorityConnectors.debug("Send search user request to API: " + newgenericEntryPoint + "?" + "username" + "=" + username);
+      final HttpGet getSecurity = new HttpGet(newgenericEntryPoint + "?" + "username" + "=" + username);
+      try (final CloseableHttpResponse response = httpClient.execute(getSecurity)) {
+        if (response.getStatusLine().getStatusCode() == 200) {
+          try (final InputStream isResp = response.getEntity().getContent()) {
+
+            JSONParser parser = new JSONParser();
+            Object obj = parser.parse(new InputStreamReader(isResp));
+
+            JSONObject jsonObject = (JSONObject) obj;
+
+            final JSONArray security = (JSONArray)  jsonObject.get("tokens");
+
+
+            for (int i = 0; i < security.size(); i++) {
+
+              String groupUser = (String) security.get(i);
+              if (! groupUser.equals("authenticated"))
+                permissions.add(groupUser);
+              if (Logging.authorityConnectors != null) {
+                Logging.authorityConnectors.debug("New generic: permission : "+groupUser);
+              }
+            }
+          } catch (ParseException e) {
+            throw new ManifoldCFException("Could not reach new generic API: " + e.getMessage(), e);
+          }
+        }
+      }
+    } catch (final IOException e) {
+      throw new ManifoldCFException("Could not reach new generic API: " + e.getMessage(), e);
+    }
+
+
+    if (permissions.size() == 0) {
+      permissions = null;
+    }
+
+    return permissions;
+
+  }
+
+  /**
+   * Obtain the default access tokens for a given user name.
+   *
+   * @param userName is the user name or identifier.
+   * @return the default response tokens, presuming that the connect method
+   * fails.
+   */
+  @Override
+  public AuthorizationResponse getDefaultAuthorizationResponse(String userName) {
+    // The default response if the getConnection method fails
+    return unreachableResponse;
+  }
+
+
+  // UI support methods.
+  //
+  // These support methods are involved in setting up authority connection configuration information. The configuration methods cannot assume that the
+  // current authority object is connected.  That is why they receive a thread context argument.
+  @Override
+  public void outputConfigurationHeader(IThreadContext threadContext, IHTTPOutput out,
+      Locale locale, ConfigParams parameters, List<String> tabsArray)
+          throws ManifoldCFException, IOException {
+
+    tabsArray.add(Messages.getString(locale, "NewGeneric.NewGenericTabName"));
+    Messages.outputResourceWithVelocity(out, locale, EDIT_CONFIGURATION_AUTHORITY_JS, null);
+
+  }
+
+  @Override
+  public void outputConfigurationBody(IThreadContext threadContext, IHTTPOutput out,
+      Locale locale, ConfigParams parameters, String tabName)
+          throws ManifoldCFException, IOException {
+    final Map<String, Object> velocityContext = new HashMap<>();
+    velocityContext.put("TabName", tabName);
+
+    fillInServerTab(velocityContext, out, parameters);
+    Messages.outputResourceWithVelocity(out, locale, EDIT_CONFIGURATION_AUTHORITY_HTML, velocityContext);
+
+
+  }
+
+  protected static void fillInServerTab(final Map<String, Object> velocityContext, final IHTTPOutput out, final ConfigParams parameters) throws ManifoldCFException {
+
+
+    String newgenericAddress = parameters.getParameter(NewGenericConfig.PARAM_ADDRESS);
+    if (newgenericAddress == null) {
+      newgenericAddress = NewGenericConfig.ADDRESS_DEFAULT;
+    }
+
+    String connectionTimeout = parameters.getParameter(NewGenericConfig.PARAM_CONNECTIONTIMEOUT);
+    if (connectionTimeout == null)   {
+      connectionTimeout = NewGenericConfig.CONNECTIONTIMEOUT_DEFAULT;
+    }
+
+    String socketTimeout = parameters.getParameter(NewGenericConfig.PARAM_SOCKETTIMEOUT);
+    if (socketTimeout == null) {
+      socketTimeout = NewGenericConfig.SOCKETTIMEOUT_DEFAULT;
+    }
+
+    String login = parameters.getParameter(NewGenericConfig.PARAM_LOGIN);
+    if (login == null) {
+      login = "";
+    }
+    String password = parameters.getParameter(NewGenericConfig.PARAM_PASSWORD);
+    if (password == null) {
+      password = "";
+    }
+
+    String responselifetime = parameters.getParameter(NewGenericConfig.PARAM_RESPONSELIFETIME);
+    if (responselifetime == null) {
+      responselifetime = NewGenericConfig.RESPONSELIFETIME_DEFAULT;
+    }
+    // Fill in context
+
+    velocityContext.put("ADDRESS", newgenericAddress);
+    velocityContext.put("CONNECTIONTIMEOUT", connectionTimeout);
+    velocityContext.put("SOCKETTIMEOUT", socketTimeout);
+    velocityContext.put("LOGIN", login);
+    velocityContext.put("PASSWORD", password);
+    velocityContext.put("RESPONSELIFETIME", responselifetime);
+
+
+  }
+
+
+  @Override
+  public String processConfigurationPost(final IThreadContext threadContext, final IPostParameters variableContext, final Locale locale, final ConfigParams parameters) throws ManifoldCFException {
+    final String newgenericAddress = variableContext.getParameter("newgenericAddress");
+
+    if (newgenericAddress != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_ADDRESS, newgenericAddress);
+    }
+
+    final String connectionTimeout = variableContext.getParameter(NewGenericConfig.PARAM_CONNECTIONTIMEOUT);
+    if (connectionTimeout != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_CONNECTIONTIMEOUT, connectionTimeout);
+    }
+
+    final String socketTimeout = variableContext.getParameter(NewGenericConfig.PARAM_SOCKETTIMEOUT);
+    if (socketTimeout != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_SOCKETTIMEOUT, socketTimeout);
+    }
+
+    final String login = variableContext.getParameter(NewGenericConfig.PARAM_LOGIN);
+    if (login != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_LOGIN, login);
+    }
+
+    final String password = variableContext.getParameter(NewGenericConfig.PARAM_PASSWORD);
+    if (password != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_PASSWORD, password);
+    }
+
+    final String responselifetime = variableContext.getParameter(NewGenericConfig.PARAM_RESPONSELIFETIME);
+    if (responselifetime != null) {
+      parameters.setParameter(NewGenericConfig.PARAM_RESPONSELIFETIME, responselifetime);
+    }
+
+    return null;
+  }
+
+
+  /**
+   * View configuration. This method is called in the body section of the connector's view configuration page. Its purpose is to present the
+   * connection information to the user. The coder can presume that the HTML that is output from this configuration will be within appropriate
+   * <html> and <body> tags.
+   *
+   * @param threadContext is the local thread context.
+   * @param out           is the output to which any HTML should be sent.
+   * @param parameters    are the configuration parameters, as they currently exist, for this connection being configured.
+   */
+  @Override
+  public void viewConfiguration(final IThreadContext threadContext, final IHTTPOutput out, final Locale locale, final ConfigParams parameters) throws ManifoldCFException, IOException {
+    final Map<String, Object> velocityContext = new HashMap<>();
+    fillInServerTab(velocityContext, out, parameters);
+    Messages.outputResourceWithVelocity(out, locale, VIEW_CONFIGURATION_AUTHORITY_HTML, velocityContext);
+  }
+
+  // Protected methods
+  protected static StringSet emptyStringSet = new StringSet();
+
+
+
+  /**
+   * This is the cache object descriptor for cached access tokens from this
+   * connector.
+   */
+  protected class GenericAuthorizationResponseDescription extends org.apache.manifoldcf.core.cachemanager.BaseDescription {
+
+    /**
+     * The user name
+     */
+    protected String userName;
+
+    /**
+     * LDAP connection string with server name and base DN
+     */
+    protected String connectionString;
+
+    /**
+     * The response lifetime
+     */
+    protected long responseLifetime;
+
+    /**
+     * The expiration time
+     */
+    protected long expirationTime = -1;
+
+    /**
+     * Constructor.
+     */
+    public GenericAuthorizationResponseDescription(String userName, String connectionString, long responseLifetime, int LRUsize) {
+      super("LDAPAuthority", LRUsize);
+      this.userName = userName;
+      this.connectionString = connectionString;
+      this.responseLifetime = responseLifetime;
+    }
+
+    /**
+     * Return the invalidation keys for this object.
+     */
+    @Override
+    public StringSet getObjectKeys() {
+      return emptyStringSet;
+    }
+
+    /**
+     * Get the critical section name, used for synchronizing the creation of the
+     * object
+     */
+    @Override
+    public String getCriticalSectionName() {
+      StringBuilder sb = new StringBuilder(getClass().getName());
+      sb.append("-").append(userName).append("-").append(connectionString);
+      return sb.toString();
+    }
+
+    /**
+     * Return the object expiration interval
+     */
+    @Override
+    public long getObjectExpirationTime(long currentTime) {
+      if (expirationTime == -1) {
+        expirationTime = currentTime + responseLifetime;
+      }
+      return expirationTime;
+    }
+
+    @Override
+    public int hashCode() {
+      return userName.hashCode() + connectionString.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (!(o instanceof GenericAuthorizationResponseDescription)) {
+        return false;
+      }
+      GenericAuthorizationResponseDescription ard = (GenericAuthorizationResponseDescription) o;
+      if (!ard.userName.equals(userName)) {
+        return false;
+      }
+      if (!ard.connectionString.equals(connectionString)) {
+        return false;
+      }
+      return true;
+    }
+  }
+
+  static class PreemptiveAuth implements HttpRequestInterceptor {
+
+    private Credentials credentials;
+
+    public PreemptiveAuth(Credentials creds) {
+      this.credentials = creds;
+    }
+
+    @Override
+    public void process(final HttpRequest request, final HttpContext context) throws HttpException, IOException {
+      request.addHeader(new BasicScheme(StandardCharsets.US_ASCII).authenticate(credentials, request, context));
+    }
+  }
+
+  protected static class CheckThread extends Thread {
+
+    protected HttpClient client;
+
+    protected String url;
+
+    protected Throwable exception = null;
+
+    protected String result = "Unknown";
+
+    public CheckThread(HttpClient client, String url) {
+      super();
+      setDaemon(true);
+      this.client = client;
+      this.url = url;
+
+    }
+
+    @Override
+    public void run() {
+      HttpGet method = new HttpGet(url);
+      try {
+        HttpResponse response = client.execute(method);
+        try {
+          if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+            result = "Connection failed: " + response.getStatusLine().getReasonPhrase();
+            return;
+          }
+          EntityUtils.consume(response.getEntity());
+          result = "Connection OK";
+        } finally {
+          EntityUtils.consume(response.getEntity());
+          method.releaseConnection();
+        }
+      } catch (IOException ex) {
+        exception = ex;
+      }
+    }
+
+    public Throwable getException() {
+      return exception;
+    }
+
+    public String getResult() {
+      return result;
+    }
+  }
+
+
+}

--- a/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/NewGenericConfig.java
+++ b/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/NewGenericConfig.java
@@ -1,0 +1,18 @@
+package org.apache.manifoldcf.authorities.authorities.newgeneric;
+
+public class NewGenericConfig {
+
+  // Connector Configuration parameters
+  public static final String PARAM_ADDRESS = "newGenericAddress";
+  public static final String PARAM_CONNECTIONTIMEOUT = "connectionTimeout";
+  public static final String PARAM_SOCKETTIMEOUT = "socketTimeout";
+  public static final String ADDRESS_DEFAULT = "http://datafari.com";
+  public static final String CONNECTIONTIMEOUT_DEFAULT = "60000";
+  public static final String SOCKETTIMEOUT_DEFAULT = "180000";
+  public static final String PARAM_LOGIN = "login";
+  public static final String PARAM_PASSWORD = "password";
+  public static final String PARAM_RESPONSELIFETIME = "responselifetime";
+  public static final String RESPONSELIFETIME_DEFAULT = "120000";
+  
+
+}

--- a/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/api/NewGenericResponse.java
+++ b/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/api/NewGenericResponse.java
@@ -1,0 +1,6 @@
+package org.apache.manifoldcf.authorities.authorities.newgeneric.api;
+
+public class NewGenericResponse {
+
+  
+}

--- a/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/api/NewGenericUser.java
+++ b/connectors/newgeneric/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/newgeneric/api/NewGenericUser.java
@@ -1,0 +1,50 @@
+package org.apache.manifoldcf.authorities.authorities.newgeneric.api;
+
+import java.util.List;
+
+public class NewGenericUser {
+
+  
+  
+  private String username;
+  private List<String> tokens;
+  boolean existsUser;
+
+  public NewGenericUser() {
+    this.username = null;
+    this.tokens = null;
+    this.existsUser = false;
+  }
+  
+  public NewGenericUser(String username, List<String> tokens,boolean existsUser ) {
+    this.username = username;
+    this.tokens = tokens;
+    this.existsUser = existsUser;
+  }
+
+
+  public String getUsername() {
+    return username;
+  }
+
+  public List<String> getTokens() {
+    return tokens;
+  }
+  
+  public void setUsername(String username) {
+    this.username = username;
+  }
+  
+  public void setTokens(List<String> tokens) {
+    this.tokens = tokens;
+  }
+  
+  public void setExistsUser(boolean existsUser) {
+    this.existsUser = existsUser;
+  }
+  
+  public boolean getExistsUser() {
+   return  existsUser ;
+    
+  }
+}

--- a/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_en_US.properties
+++ b/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_en_US.properties
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NewGeneric.NewGenericTabName=JSON Generic Parameters
+NewGeneric.NewGenericAddress=URL:
+NewGeneric.Login=Login
+NewGeneric.Password=Password
+NewGeneric.ConnectionTimeout=Connection timeout (milis):
+NewGeneric.SocketTimeout=Socket timeout (milis):
+NewGeneric.ResponseLifetimeColon=Response life time (milis):
+NewGeneric.ResponseLifetime=Response life time (milis):
+NewGeneric.NoValueSecurityField=No value entered for Security field
+NewGeneric.NoValueCollection=No value entered for collection
+NewGeneric.NoValueIdField=No value entered for field Id
+NewGeneric.NoValueDateField=No value entered for field Date
+NewGeneric.NoValueSolrAddress=No value entered for Solr address
+NewGeneric.NoValueConnectionTimeOut= No value entered for connection timeout
+NewGeneric.NoValueSocketTimeOut=No value entered for socket timeout
+NewGeneric.NoValueResponseLifeTime=No value entered for response life time

--- a/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_es_ES.properties
+++ b/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_es_ES.properties
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NewGeneric.NewGenericTabName=JSON Generic Parameters
+NewGeneric.NewGenericAddress=URL:
+NewGeneric.Login=Login
+NewGeneric.Password=Password
+NewGeneric.ConnectionTimeout=Connection timeout (milis):
+NewGeneric.SocketTimeout=Socket timeout (milis):
+NewGeneric.ResponseLifetimeColon=Response life time (milis):
+NewGeneric.ResponseLifetime=Response life time (milis):
+NewGeneric.NoValueSecurityField=No value entered for Security field
+NewGeneric.NoValueCollection=No value entered for collection
+NewGeneric.NoValueIdField=No value entered for field Id
+NewGeneric.NoValueDateField=No value entered for field Date
+NewGeneric.NoValueSolrAddress=No value entered for Solr address
+NewGeneric.NoValueConnectionTimeOut= No value entered for connection timeout
+NewGeneric.NoValueSocketTimeOut=No value entered for socket timeout
+NewGeneric.NoValueResponseLifeTime=No value entered for response life time

--- a/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_fr_FR.properties
+++ b/connectors/newgeneric/connector/src/main/native2ascii/org/apache/manifoldcf/authorities/authorities/newgeneric/common_fr_FR.properties
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+NewGeneric.NewGenericTabName=JSON Generic Parameters
+NewGeneric.NewGenericAddress=URL:
+NewGeneric.Login=Login:
+NewGeneric.Password=Mot de passe:
+NewGeneric.ConnectionTimeout=Connection timeout(milis):
+NewGeneric.SocketTimeout=Socket timeout(milis):
+NewGeneric.LoginColon=Login:
+NewGeneric.PasswordColon=Password:
+NewGeneric.ConnectionTimeoutColon=Connection timeout (milis):
+NewGeneric.SocketTimeoutColon=Socket timeout (milis):
+NewGeneric.ResponseLifetimeColon=Temps de cache (milis):
+NewGeneric.ResponseLifetime=Temps de cache (milis):
+NewGeneric.NoValueSecurityField=No value entered for Security field
+NewGeneric.NoValueCollection=No value entered for collection
+NewGeneric.NoValueIdField=No value entered for field Id
+NewGeneric.NoValueDateField=No value entered for field Date
+NewGeneric.NoValueSolrAddress=No value entered for Solr address
+NewGeneric.NoValueConnectionTimeOut=No value entered for connection timeout
+NewGeneric.NoValueSocketTimeOut=No value entered for socket timeout
+NewGeneric.NoValueResponseLifeTime=No value entered for life time response

--- a/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/editConfiguration.js
+++ b/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/editConfiguration.js
@@ -1,0 +1,55 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<script type="text/javascript">
+<!--
+
+function checkConfigForSave()
+{
+  if (editconnection.newgenericAddress.value == "")
+  {
+    alert("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NoValueNewGenericAddress'))");
+    SelectTab("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NewGenericTabName'))");
+    eval("editconnection.newgenericAddress.focus()");
+    return false;
+  }
+  if (editconnection.connectionTimeout.value == "")
+  {
+    alert("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NoValueConnectionTimeOut'))");
+    SelectTab("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NewGenericTabName'))");
+    eval("editconnection.connectionTimeout.focus()");
+    return false;
+  }
+  if (editconnection.socketTimeout.value == "")
+  {
+    alert("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NoValueSocketTimeOut'))");
+    SelectTab("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NewGenericTabName'))");
+    eval("editconnection.socketTimeout.focus()");
+    return false;
+  }
+  if (editconnection.responselifetime.value == "")
+  {
+    alert("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NoValueResponseLifeTime'))");
+    SelectTab("$Encoder.bodyJavascriptEscape($ResourceBundle.getString('NewGeneric.NewGenericTabName'))");
+    eval("editconnection.responselifetime.focus()");
+    return false;
+  }
+  return true;
+}
+
+//-->
+</script>

--- a/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/editConfiguration_Server.html
+++ b/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/editConfiguration_Server.html
@@ -1,0 +1,68 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+#if($TabName == $ResourceBundle.getString('NewGeneric.NewGenericTabName'))
+
+<table class="displaytable">
+  <tr><td class="separator" colspan="2"><hr/></td></tr>
+  <tr>
+     <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.NewGenericAddress'))</nobr></td>
+    <td class="value"><input name="newgenericAddress" type="text"
+      value="$Encoder.attributeEscape($ADDRESS)" size="40" />
+    </td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.Login'))</nobr></td>
+    <td class="value"><input name="login" type="text"
+      value="$Encoder.attributeEscape($LOGIN)" size="20" />
+    </td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.Password'))</nobr></td>
+    <td class="value"><input type="password" name="password" type="text"
+      value="$Encoder.attributeEscape($PASSWORD)" size="20" />
+    </td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.ResponseLifetimeColon'))</nobr></td>
+    <td class="value"><input name="responselifetime" type="text"
+      value="$Encoder.attributeEscape($RESPONSELIFETIME)" size="20" />
+    </td>
+  </tr>
+   <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.ConnectionTimeout'))</nobr></td>
+    <td class="value"><input name="connectionTimeout" type="text"
+      value="$Encoder.attributeEscape($CONNECTIONTIMEOUT)" size="20" />
+    </td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.SocketTimeout'))</nobr></td>
+    <td class="value"><input name="socketTimeout" type="text"
+      value="$Encoder.attributeEscape($SOCKETTIMEOUT)" size="20" />
+    </td>
+  </tr>
+ 
+  
+</table>
+#else
+<input type="hidden" name="newgenericAddress" value="$ADDRESS"/>
+<input type="hidden" name="login" value="$LOGIN"/>
+<input type="hidden" name="password" value="$PASSWORD"/>
+<input type="hidden" name="responselifetime" value="$RESPONSELIFETIME"/>
+<input type="hidden" name="connectionTimeout" value="$CONNECTIONTIMEOUT"/>
+<input type="hidden" name="socketTimeout" value="$SOCKETTIMEOUT"/>
+
+#end

--- a/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/viewConfiguration.html
+++ b/connectors/newgeneric/connector/src/main/resources/org/apache/manifoldcf/authorities/authorities/newgeneric/viewConfiguration.html
@@ -1,0 +1,44 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<table class="displaytable">
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.NewGenericAddress'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($ADDRESS)</nobr></td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.Login'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($LOGIN)</nobr></td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.Password'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($PASSWORD)</nobr></td>
+  </tr>
+    <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.ConnectionTimeout'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($CONNECTIONTIMEOUT)</nobr></td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.SocketTimeout'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($SOCKETTIMEOUT)</nobr></td>
+  </tr>
+  <tr>
+    <td class="description"><nobr>$Encoder.bodyEscape($ResourceBundle.getString('NewGeneric.ResponseLifetime'))</nobr></td>
+    <td class="value"><nobr>$Encoder.bodyEscape($RESPONSELIFETIME)</nobr></td>
+  </tr>
+ 
+</table>

--- a/connectors/newgeneric/pom.xml
+++ b/connectors/newgeneric/pom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.manifoldcf</groupId>
+        <artifactId>mcf-connectors</artifactId>
+        <version>2.27-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mcf-newgeneric-connector</artifactId>
+    <name>ManifoldCF - Connectors - New Generic</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <build>
+        <defaultGoal>integration-test</defaultGoal>
+        <sourceDirectory>${basedir}/connector/src/main/java</sourceDirectory>
+        <testSourceDirectory>${basedir}/connector/src/test/java</testSourceDirectory>
+        <resources>
+            <resource>
+                <directory>${basedir}/connector/src/main/native2ascii</directory>
+                <includes>
+                    <include>**/*.properties</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>${basedir}/connector/src/main/resources</directory>
+                <includes>
+                    <include>**/*.html</include>
+                    <include>**/*.js</include>
+                </includes>
+            </resource>
+        </resources>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/connector/src/test/resources</directory>
+            </testResource>
+        </testResources>
+    </build>
+
+    <dependencies>
+        <!-- MCF dependencies -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mcf-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mcf-agents</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mcf-connector-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mcf-pull-agent</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>mcf-ui-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.7</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.6</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -81,6 +81,7 @@
     <module>mongodb</module>
     <module>csws</module>
     <module>csv</module>
+    <module>newgeneric</module>
   </modules>
 
 </project>


### PR DESCRIPTION
The current MCF generic authority connector is taking XML for input. As time goes, JSON is now another frequently used data exchange format. So I have created a new generic connector, able to take json as input, instead of XML. Would you be interested in integrating it into ManifoldCF? The corresponding documentation can be found here: https://datafari.atlassian.net/wiki/spaces/DATAFARI/pages/2835021825/New+generic+authority+connector

Additionally to this new connector, I have fixed a syntax error in csv connector pom.