### PR TITLE
Update Solr Ingester connector to ingest Solr 9 documents.

### DIFF
--- a/connectors/solr/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/solr/SolrIngesterConnector.java
+++ b/connectors/solr/connector/src/main/java/org/apache/manifoldcf/crawler/connectors/solr/SolrIngesterConnector.java
@@ -680,11 +680,8 @@ public class SolrIngesterConnector extends BaseRepositoryConnector {
 
               // TODO
               // For now you can indicate the date field of the source. But the date field of the target is hardcoded and its value is last_modified
-              if (document.getFieldValues(dateField).size() > 1) { // ensure that the date field is single valued
-                doc.addField(date_target_field, (Date) document.getFirstValue(dateField));
-              }
-              else {
-                doc.addField(date_target_field, (Date) document.getFieldValue(dateField));
+             if (document.get(dateField)!= null) {              
+               doc.addField(date_target_field, (Date) document.getFirstValue(dateField));
               }
               doc.setFileName((String) document.getFieldValue(idFieldName));
 

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -55,6 +55,7 @@
             <include name="http2*.jar"/>
             <include name="httpcore*.jar"/>
             <include name="httpclient*.jar"/>
+            <include name="httpmime*.jar"/>
             <include name="commons-io*.jar"/>
             <include name="commons-lang*.jar"/>
             <include name="commons-logging*.jar"/>
@@ -1085,6 +1086,7 @@
                 <include name="commons-fileupload*.jar"/>
                 <include name="httpcore*.jar"/>
                 <include name="httpclient*.jar"/>
+                <include name="httpmime*.jar"/>                
                 <include name="commons-io*.jar"/>
                 <include name="commons-lang*.jar"/>
                 <include name="commons-logging*.jar"/>
@@ -1363,6 +1365,7 @@
             <include name="slf4j-simple*.jar"/>
             <include name="httpcore*.jar"/>
             <include name="httpclient*.jar"/>
+            <include name="httpmime*.jar"/>            
             <include name="javax.mail*.jar"/>
             <include name="commons-exec*.jar"/>
             <include name="gson*.jar"/>

--- a/framework/buildfiles/connector-build.xml
+++ b/framework/buildfiles/connector-build.xml
@@ -130,6 +130,7 @@
             <include name="commons-fileupload*.jar"/>
             <include name="httpcore*.jar"/>
             <include name="httpclient*.jar"/>
+            <include name="httpmime*.jar"/>
             <include name="commons-io*.jar"/>
             <include name="commons-lang*.jar"/>
             <include name="commons-logging*.jar"/>


### PR DESCRIPTION
The Solr Ingestor needed a little fix to ingest Solr 9 documents. The "httpmime" dependency was missing from the distribution packaging. With Solr 9, a bug in Date field filling was discovered and fixed. We are using it in our application.

We are currently using these fixes in our application. 

I have run "ant test" and all passed except for elasticsearch IT-HSQLDB tests. I get back up until 2.25 and they were already showing the same failures.