### PR TITLE
Fixing vulnerabilities

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -30,7 +30,7 @@
     <defaultexcludes add="**/.idea/**"/> 
 
     <property name="javax-activation.version" value="1.2.0"/>
-    <property name="hsqldb.version" value="2.3.2"/>
+    <property name="hsqldb.version" value="2.7.3"/>
     <property name="jetty.version" value="9.4.48.v20220622"/>
     <property name="httpclient.version" value="4.5.13"/>
     <property name="httpmime.version" value="4.5.13"/>

--- a/build.xml
+++ b/build.xml
@@ -931,7 +931,7 @@ Use Apache Forrest version forrest-0.9-dev or higher.
         </antcall>
         <antcall target="download-via-maven">
             <param name="project-path" value="com/squareup/retrofit2"/>
-            <param name="artifact-version" value="2.3.0"/>
+            <param name="artifact-version" value="2.11.0"/>
             <param name="target" value="lib"/>
             <param name="artifact-name" value="retrofit"/>
             <param name="artifact-type" value="jar"/>

--- a/build.xml
+++ b/build.xml
@@ -177,7 +177,7 @@
     <property name="resteasy.client.version" value="3.0.16.Final"/>
     <property name="jsoup.version" value="1.11.3"/>
     <property name="jj2000.version" value="5.2"/>
-    <property name="hadoop.version" value="2.6.0"/>
+    <property name="hadoop.version" value="3.3.6"/>
     <property name="aws-sdk.version" value="1.9.0"/>
     <property name="joda-time.version" value="2.9.7"/>
     <property name="junrar.version" value="7.4.1"/>

--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,7 @@
     <property name="metrics-core.version" value="4.2.21"/>
     <property name="snappy-java.version" value="1.1.7.7"/>
     <property name="mongodb.version" value="2.14.3"/>
-    <property name="postgresql.version" value="42.1.3"/>
+    <property name="postgresql.version" value="42.7.4"/>
     <property name="axis.version" value="1.4"/>
     <property name="saaj-api.version" value="1.3"/>
     <property name="saaj-impl.version" value="1.5.1"/>

--- a/build.xml
+++ b/build.xml
@@ -197,7 +197,7 @@
     <property name="sentiment-analysis.version" value="0.1"/>
     <property name="uimafit.version" value="2.2.0"/>
     <property name="uimaj.version" value="2.9.0"/>
-    <property name="cxf.version" value="3.5.0"/>
+    <property name="cxf.version" value="3.5.9"/>
     <property name="policy.version" value="2.7.6"/>
     <property name="gmbal.version" value="4.0.0"/>
     <property name="management-api.version" value="3.2.1"/>

--- a/build.xml
+++ b/build.xml
@@ -191,7 +191,6 @@
     <property name="jsr-275.version" value="0.9.3"/>
     <property name="commons-vfs2.version" value="2.0"/>
     <property name="maven-scm.version" value="1.4"/>
-    <property name="plexus-utils.version" value="1.5.6"/>
     <property name="regexp.version" value="1.3"/>
     <property name="c3p0.version" value="0.9.5.5"/>
     <property name="sentiment-analysis.version" value="0.1"/>
@@ -2938,12 +2937,6 @@ Use Apache Forrest version forrest-0.9-dev or higher.
             <param name="project-path" value="org/apache/maven/scm"/>
             <param name="artifact-version" value="${maven-scm.version}"/>
             <param name="artifact-name" value="maven-scm-provider-svn-commons"/>
-            <param name="artifact-type" value="jar"/>
-        </antcall>
-        <antcall target="download-via-maven"><param name="target" value="lib"/>
-            <param name="project-path" value="org/codehaus/plexus"/>
-            <param name="artifact-version" value="${plexus-utils.version}"/>
-            <param name="artifact-name" value="plexus-utils"/>
             <param name="artifact-type" value="jar"/>
         </antcall>
         <antcall target="download-via-maven"><param name="target" value="lib"/>

--- a/framework/build.xml
+++ b/framework/build.xml
@@ -132,7 +132,6 @@
             <include name="junrar*.jar"/>
             <include name="commons-vfs2*.jar"/>
             <include name="maven-scm*.jar"/>
-            <include name="plexus-utils*.jar"/>
             <include name="regexp*.jar"/>
             <include name="commons-csv*.jar"/>
             <include name="netcdf4*.jar"/>
@@ -1644,7 +1643,6 @@
                 <include name="junrar*.jar"/>
                 <include name="commons-vfs2*.jar"/>
                 <include name="maven-scm*.jar"/>
-                <include name="plexus-utils*.jar"/>
                 <include name="regexp*.jar"/>
                 <include name="commons-csv*.jar"/>
                 <include name="netcdf4*.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <selenium.version>3.13.0</selenium.version>
     <mockito.version>1.9.5</mockito.version>
     <wiremock.version>2.5.1</wiremock.version>
-    <postgresql.version>42.1.3</postgresql.version>
+    <postgresql.version>42.7.4</postgresql.version>
     <mysql.version>5.1.47</mysql.version>
     <hsqldb.version>2.3.2</hsqldb.version>
     <jetty.version>9.4.48.v20220622</jetty.version>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <wiremock.version>2.5.1</wiremock.version>
     <postgresql.version>42.7.4</postgresql.version>
     <mysql.version>5.1.47</mysql.version>
-    <hsqldb.version>2.3.2</hsqldb.version>
+    <hsqldb.version>2.7.3</hsqldb.version>
     <jetty.version>9.4.48.v20220622</jetty.version>
     <jetty-jsp-jdt.version>2.3.3</jetty-jsp-jdt.version>
     <jetty-schemas.version>3.1.M0</jetty-schemas.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <xmlbeans.version>2.6.0</xmlbeans.version>
     <poi.version>3.17</poi.version>
     <tika.version>1.28.1</tika.version>    <boilerpipe.version>1.1.0</boilerpipe.version>
-    <hadoop.version>2.6.0</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <tomcat.version>6.0.35</tomcat.version>
     <ecj.version>4.3.1</ecj.version>
     <json-simple.version>1.1.1</json-simple.version>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <gson.version>2.8.0</gson.version>
     <guava.version>21.0</guava.version>
     <jsoup.version>1.7.2</jsoup.version>
-    <cxf.version>3.5.0</cxf.version>
+    <cxf.version>3.5.9</cxf.version>
     <jaxws-ri.version>2.3.2</jaxws-ri.version>
     <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>


### PR DESCRIPTION
The Trivy tool (https://trivy.dev/) reveals a number of vulnerabilities in ManifoldCF. This contribution fixes the critical ones on CXF, hadoop, Plexus utils, Postgresql, Retrofit and HSQL.

We have tested Web connector and Windows Share which are still working properly.

It seems that the HSQL update broke the tests-HSQLDB-framework, but even without the fix, I'm getting errors on the connectors-IT-HSQLDB... Are there other members of the community who could work on checking and updating the tests that are useful to them?