### PR TITLE
Fix JDBC authority edition error on "Database type" tab.

### DIFF
--- a/connectors/jdbc/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/jdbc/JDBCAuthority.java
+++ b/connectors/jdbc/connector/src/main/java/org/apache/manifoldcf/authorities/authorities/jdbc/JDBCAuthority.java
@@ -450,7 +450,6 @@ public class JDBCAuthority extends BaseAuthorityConnector {
 "        <option value=\"jtds:sybase://\" " + (lJdbcProvider.equals("jtds:sybase:") ? "selected=\"selected\"" : "") + ">Sybase (&gt;= V10)</option>\n"+
 "        <option value=\"mysql://\" " + (lJdbcProvider.equals("mysql:") ? "selected=\"selected\"" : "") + ">MySQL (&gt;= V5)</option>\n"+
 "        <option value=\"mariadb://\" " + (lJdbcProvider.equals("mariadb:") ? "selected=\"selected\"" : "") + ">MariaDB</option>\n"+
-"        <option value=\"xbib:csv:\" "+(jdbcProvider.equals("xbib:csv:")?"selected=\"selected\"":"")+">CSV</option>\n"+
 "      </select>\n"+
 "    </td>\n"+
 "  </tr>\n"+


### PR DESCRIPTION
The "Database type" has nothing to do with CSV files access, so this option should be removed as it blocks the page display.
Furthermore, the CSV files management in JDBC connector was an old trick, but it is replaced now by the CSV connector.