### PR TITLE
fix: armor equals in RepriorizationTracker agains null bin names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 ManifoldCF Change Log
 
-======================= 2.29-dev =========================
+======================= Release 2.30-dev ======================
+
+CONNECTORS-1720: Armor equals method in RepriorizationTracker against null bin names
+(Markus Schuch)
+
+======================= Release 2.29 ==========================
 
 CONNECTORS-1776: Update Copyright footer to 2025
 (Piergiorgio Lucidi)

--- a/connectors/nuxeo/pom.xml
+++ b/connectors/nuxeo/pom.xml
@@ -52,7 +52,7 @@
   <repositories>
     <repository>
 	  <id>public-releases</id>
-	  <url>https://packages.nuxeo.com/repository/maven-public-archives</url>
+	  <url>https://maven.nuxeo.org/nexus/content/repositories/public-releases</url>
     </repository>
   </repositories>
   <!-- Nuxeo repositories -->

--- a/framework/pull-agent/src/main/java/org/apache/manifoldcf/crawler/reprioritizationtracker/ReprioritizationTracker.java
+++ b/framework/pull-agent/src/main/java/org/apache/manifoldcf/crawler/reprioritizationtracker/ReprioritizationTracker.java
@@ -465,7 +465,7 @@ public class ReprioritizationTracker implements IReprioritizationTracker
         return false;
       final PreloadKey pk = (PreloadKey)o;
       return connectorClass.equals(pk.connectorClass) &&
-        binName.equals(pk.binName);
+        (binName == null ? "" : binName).equals(pk.binName);
     }
   }
   


### PR DESCRIPTION
Addition for the fixes in [CONNECTORS-1720](https://issues.apache.org/jira/browse/CONNECTORS-1720) that were incomplete.

Also updates the maven repository url for nuxes to fix the maven build.